### PR TITLE
Ci/setup deploy and test

### DIFF
--- a/.github/workflows/build-check-deploy.yml
+++ b/.github/workflows/build-check-deploy.yml
@@ -27,7 +27,6 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       will-release: ${{ steps.compute-next-version.outputs.will-release }}
-      next-version: ${{ steps.compute-next-version.outputs.next-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/build-check-deploy.yml
+++ b/.github/workflows/build-check-deploy.yml
@@ -83,16 +83,22 @@ jobs:
           cd common
           npm publish --registry http://localhost:4873/
 
-      - name: Install dependencies for API project
+      - name: Install dependencies for api project
         run: |
           cd api
+          npm install --registry http://localhost:4873/
+
+      - name: Run api test
+        run: cd api && npm run check
+
+      - name: Install dependencies for auth project
+        run: |
+          cd auth
           npm install --registry http://localhost:4873/
 
       - name: Run auth test
         run: cd auth && npm run check
 
-      - name: Run api test
-        run: cd api && npm run check
 
   release:
     concurrency:

--- a/.github/workflows/build-check-deploy.yml
+++ b/.github/workflows/build-check-deploy.yml
@@ -89,10 +89,10 @@ jobs:
           npm install --registry http://localhost:4873/
 
       - name: Run auth test
-        run: cd auth && npm check
+        run: cd auth && npm run check
 
       - name: Run api test
-        run: cd api && npm check
+        run: cd api && npm run check
 
   release:
     concurrency:

--- a/.github/workflows/build-check-deploy.yml
+++ b/.github/workflows/build-check-deploy.yml
@@ -147,12 +147,12 @@ jobs:
     needs:
       - check-secrets
       - test-and-check
-      #      - precompute-next-version
-      #- release
-    #    if: |
-    #      !cancelled() &&
-    #      !contains(needs.precompute-next-version.result, 'failure') &&
-    #      needs.precompute-next-version.outputs.will-release == 'true'
+      - precompute-next-version
+      - release
+    if: |
+      !cancelled() &&
+      !contains(needs.precompute-next-version.result, 'failure') &&
+      needs.precompute-next-version.outputs.will-release == 'true'
     strategy:
       matrix:
         service: [ api, auth ]

--- a/.github/workflows/build-check-deploy.yml
+++ b/.github/workflows/build-check-deploy.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       will-release: ${{ steps.compute-next-version.outputs.will-release }}
+      next-version: ${{ steps.compute-next-version.outputs.next-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/build-check-deploy.yml
+++ b/.github/workflows/build-check-deploy.yml
@@ -41,72 +41,97 @@ jobs:
         with:
           github-token: ${{ github.token }}
 
-  check:
-    strategy:
-      matrix:
-        submodule: [ common, auth, api ]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.2.2
-      - run: |
-          cd ${{ matrix.submodule }}
-          npm ci
-          npm run lint:check
-          npm run format:check
-
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ windows-2022, macos-14, ubuntu-24.04 ]
-    runs-on: ${{ matrix.os }}
+  test-and-check:
+    runs-on: ubuntu-latest
     needs:
       - check-secrets
-      - check
     steps:
-      - name: Checkout
-        uses: DanySK/action-checkout@0.2.22
-      - uses: actions/setup-node@v4.1.0
-#      - name: Publish with Verdaccio
-#        uses: verdaccio/github-actions/publish@master
-#        working-directory: common
-      - name: Install dependencies and run tests
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run tests on the common project
         run: |
-          cd api && npm ci && npm run build && npm run test --passWithNoTests
-          cd ../auth && npm ci && npm run build && npm run test --passWithNoTests
-          cd ..
+          cd common
+          npm install
+          npm run lint:check
+          npm run format:check
+          npm test
+
+      - name: Build Verdaccio Docker Image
+        run: |
+          cd common
+          docker build -t c-verdaccio .
+          docker run -d --name verdaccio -p 4873:4873 c-verdaccio
+
+      - name: Wait for Verdaccio to be ready
+        run: |
+          for i in {1..30}; do
+            if curl --silent --fail http://localhost:4873/-/ping; then
+              echo "Verdaccio is ready!"
+              exit 0
+            fi
+            echo "Waiting for Verdaccio..."
+            sleep 2
+          done
+          echo "Verdaccio did not start in time" >&2
+          exit 1
+
+      - name: Configure npm to use Verdaccio
+        run: |
+          echo "//localhost:4873/:_authToken=\"fake-token\"" > ~/.npmrc
+          echo "always-auth=true" >> ~/.npmrc
+
+      - name: Publish local package
+        run: |
+          cd common
+          npm publish --registry http://localhost:4873/
+
+      - name: Install dependencies for API project
+        run: |
+          cd api
+          npm install --registry http://localhost:4873/
+
+      - name: Run tests inside projects
+        strategy:
+          matrix:
+            module: [auth, api]
+        run: |
+          cd ${{ matrix.module }}
+          npm run lint:check
+          npm run format:check
+          npm test 
+          npm run build
+      
 
   release:
-    strategy:
-      matrix:
-        submodule: [ common, auth, api ]
     concurrency:
       # Only one release job at a time per branch, as only master releases.
       # Strictly sequential.
       group: release-${{ github.event.number || github.ref }}
-    permissions: write-all
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04
     needs:
       - check-secrets
-      - check
-      - build
+      - test-and-check
     if: |
       always() &&
-      needs.check-secrets.outputs.run-with-secrets == 'true' &&
-      needs.check.result == 'success'
+      needs.check-secrets.outputs.run-with-secrets == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.DEPLOYMENT_TOKEN }}
+      - uses: actions/setup-node@v4.1.0
+        with:
+          cache: npm
+          node-version: lts/*
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          cd ${{ matrix.submodule }}
-          npm install
           npm ci
           npx semantic-release
 
@@ -120,12 +145,17 @@ jobs:
       group: deploy-to-registry-${{ github.event.number || github.ref }}
     runs-on: ubuntu-24.04
     needs:
-      - precompute-next-version
-      - release
-    if: |
-      !cancelled() &&
-      !contains(needs.precompute-next-version.result, 'failure') &&
-      needs.precompute-next-version.outputs.will-release == 'true'
+      - check-secrets
+      - test-and-check
+      #      - precompute-next-version
+      #- release
+    #    if: |
+    #      !cancelled() &&
+    #      !contains(needs.precompute-next-version.result, 'failure') &&
+    #      needs.precompute-next-version.outputs.will-release == 'true'
+    strategy:
+      matrix:
+        service: [ api, auth ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -139,27 +169,26 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.service }}
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
-          context: .
+          context: ${{ matrix.service }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}-${{ matrix.service }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
   success:
     runs-on: ubuntu-latest
     needs:
-      - build
-      - check
+      - test-and-check
       - release
       - deploy-to-registry
     if: >-

--- a/.github/workflows/build-check-deploy.yml
+++ b/.github/workflows/build-check-deploy.yml
@@ -24,9 +24,6 @@ jobs:
           echo "run-with-secrets=${{ steps.detect-secrets.outputs.has-secrets == 'true' && !github.event.repository.fork }}" >> $GITHUB_OUTPUT
 
   precompute-next-version:
-    strategy:
-      matrix:
-        submodule: [ common, auth, api ]
     runs-on: ubuntu-24.04
     outputs:
       will-release: ${{ steps.compute-next-version.outputs.will-release }}

--- a/.github/workflows/build-check-deploy.yml
+++ b/.github/workflows/build-check-deploy.yml
@@ -91,17 +91,11 @@ jobs:
           cd api
           npm install --registry http://localhost:4873/
 
-      - name: Run tests inside projects
-        strategy:
-          matrix:
-            module: [auth, api]
-        run: |
-          cd ${{ matrix.module }}
-          npm run lint:check
-          npm run format:check
-          npm test 
-          npm run build
-      
+      - name: Run auth test
+        run: cd auth && npm check
+
+      - name: Run api test
+        run: cd api && npm check
 
   release:
     concurrency:

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts-alpine
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install --only=production
+
+COPY dist ./dist
+
+EXPOSE 3000
+
+CMD ["node", "dist/app.js"]

--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,8 @@
     "lint:fix": "eslint src/ --fix",
     "lint:check": "eslint src/",
     "format:write": "prettier --write src/",
-    "format:check": "prettier --check src/"
+    "format:check": "prettier --check src/",
+    "check": "npm run lint:check && npm run format:check && npm test && npm run build"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts-alpine
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install --only=production
+
+COPY dist ./dist
+
+EXPOSE 3000
+
+CMD ["node", "dist/app.js"]

--- a/auth/package.json
+++ b/auth/package.json
@@ -14,7 +14,8 @@
     "lint:fix": "eslint src/ --fix",
     "lint:check": "eslint src/",
     "format:write": "prettier --write src/",
-    "format:check": "prettier --check src/"
+    "format:check": "prettier --check src/",
+    "check": "npm run lint:check && npm run format:check && npm test && npm run build"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:lts-alpine as builder
+
+RUN mkdir -p /verdaccio/plugins \
+  && cd /verdaccio/plugins \
+  && npm install --global-style --no-bin-links --omit=optional verdaccio-auth-memory@latest
+
+FROM verdaccio/verdaccio:5
+
+ADD conf/config.yaml /verdaccio/conf/config.yaml
+
+USER root
+RUN npm install --global verdaccio-static-token \
+  && npm install --global verdaccio-auth-memory
+
+USER $VERDACCIO_USER_UID

--- a/common/conf/config.yaml
+++ b/common/conf/config.yaml
@@ -1,0 +1,22 @@
+storage: ../storage
+auth:
+  htpasswd:
+    file: ./htpasswd
+    max_users: -1
+security:
+  api:
+    jwt:
+      sign:
+        expiresIn: 7d
+      verify:
+        algorithms: ['HS256']
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  '**':
+    access: $all
+    publish: $all
+    proxy: npmjs
+logs:
+  - {type: stdout, format: pretty, level: http}

--- a/common/package.json
+++ b/common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mini-roostico/common",
+  "name": "@mini-roostico/api-common",
   "version": "1.0.5",
   "description": "Common components shared between services of the organization",
   "license": "ISC",

--- a/common/package.json
+++ b/common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "common",
+  "name": "@mini-roostico/common",
   "version": "1.0.5",
   "description": "Common components shared between services of the organization",
   "license": "ISC",

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,5 +1,5 @@
 const publishCmd = `
-cd common && npm publish --access public
+cd common && npm version $SEMANTIC_RELEASE_NEXT_VERSION && npm publish --access public
 `
 
 import config from 'semantic-release-preconfigured-conventional-commits' with { type: "json" };

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,8 +1,15 @@
+const publishCmd = `
+cd common && npm publish --access public
+`
+
 import config from 'semantic-release-preconfigured-conventional-commits' with { type: "json" };
 
 config.plugins.push(
+    "@semantic-release/exec",
+    {
+      "publishCmd": publishCmd,
+    },
     "@semantic-release/github",
     "@semantic-release/git",
-);
-
-export default config;
+)
+export default config


### PR DESCRIPTION
Added setup of CI for automatic testing, release and deploy.

Testing `auth` and `api` modules exploits `verdaccio` through a Docker image in order to publish the `common` package to a local registry